### PR TITLE
Adding dependencies to be installed in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Cython>=0.20.2
 argparse>=1.2.1
 futures>=2.1.6
 six>=1.7.3
-gensim==0.10.2
+gensim==0.10.1
 scipy>=0.7.0
 psutil>=2.1.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requirements = [
     'argparse>=1.2.1',
     'futures>=2.1.6',
     'six>=1.7.3',
+    'gensim==0.10.1',
     'scipy>=0.7.0',
     'psutil>=2.1.1',
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,13 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = [
-    # TODO: put package requirements here
+    'wheel>=0.23.0',
+    'Cython>=0.20.2',
+    'argparse>=1.2.1',
+    'futures>=2.1.6',
+    'six>=1.7.3',
+    'scipy>=0.7.0',
+    'psutil>=2.1.1',
 ]
 
 test_requirements = [


### PR DESCRIPTION
gensim version downgraded to 0.10.1 as 0.10.2 does not install via easy_install due to this bug: https://groups.google.com/forum/#!topic/gensim/NSOXuP4IE9Q

