### PR TITLE
Solve the compatibility issue with higher version of Gensim

### DIFF
--- a/deepwalk/graph.py
+++ b/deepwalk/graph.py
@@ -33,7 +33,7 @@ __email__ = "bperozzi@cs.stonybrook.edu"
 LOGFORMAT = "%(asctime).19s %(levelname)s %(filename)s: %(lineno)s %(message)s"
 
 class Graph(defaultdict):
-  """Efficient basic implementation of nx `Graph' â€“ Undirected graphs with self loops"""  
+  """Efficient basic implementation of nx `Graph' â€“ Undirected graphs with self loops"""
   def __init__(self):
     super(Graph, self).__init__(list)
 
@@ -45,22 +45,22 @@ class Graph(defaultdict):
 
   def subgraph(self, nodes={}):
     subgraph = Graph()
-    
+
     for n in nodes:
       if n in self:
         subgraph[n] = [x for x in self[n] if x in nodes]
-        
+
     return subgraph
 
   def make_undirected(self):
-  
+
     t0 = time()
 
     for v in self.keys():
       for other in self[v]:
         if v != other:
           self[other].append(v)
-    
+
     t1 = time()
     logger.info('make_directed: added missing edges {}s'.format(t1-t0))
 
@@ -71,7 +71,7 @@ class Graph(defaultdict):
     t0 = time()
     for k in iterkeys(self):
       self[k] = list(sorted(set(self[k])))
-    
+
     t1 = time()
     logger.info('make_consistent: made consistent in {}s'.format(t1-t0))
 
@@ -85,10 +85,10 @@ class Graph(defaultdict):
     t0 = time()
 
     for x in self:
-      if x in self[x]: 
+      if x in self[x]:
         self[x].remove(x)
         removed += 1
-    
+
     t1 = time()
 
     logger.info('remove_self_loops: removed {} loops in {}s'.format(removed, (t1-t0)))
@@ -99,7 +99,7 @@ class Graph(defaultdict):
       for y in self[x]:
         if x == y:
           return True
-    
+
     return False
 
   def has_edge(self, v1, v2):
@@ -115,7 +115,7 @@ class Graph(defaultdict):
 
   def order(self):
     "Returns the number of nodes in the graph"
-    return len(self)    
+    return len(self)
 
   def number_of_edges(self):
     "Returns the number of nodes in the graph"
@@ -148,7 +148,7 @@ class Graph(defaultdict):
           path.append(path[0])
       else:
         break
-    return path
+    return [str(node) for node in path]
 
 # TODO add build_walks in here
 
@@ -157,12 +157,12 @@ def build_deepwalk_corpus(G, num_paths, path_length, alpha=0,
   walks = []
 
   nodes = list(G.nodes())
-  
+
   for cnt in range(num_paths):
     rand.shuffle(nodes)
     for node in nodes:
       walks.append(G.random_walk(path_length, rand=rand, alpha=alpha, start=node))
-  
+
   return walks
 
 def build_deepwalk_corpus_iter(G, num_paths, path_length, alpha=0,
@@ -194,7 +194,7 @@ def parse_adjacencylist(f):
       row = [introw[0]]
       row.extend(set(sorted(introw[1:])))
       adjlist.extend([row])
-  
+
   return adjlist
 
 def parse_adjacencylist_unchecked(f):
@@ -202,7 +202,7 @@ def parse_adjacencylist_unchecked(f):
   for l in f:
     if l and l[0] != "#":
       adjlist.extend([[int(x) for x in l.strip().split()]])
-  
+
   return adjlist
 
 def load_adjacencylist(file_, undirected=False, chunksize=10000, unchecked=True):
@@ -220,11 +220,11 @@ def load_adjacencylist(file_, undirected=False, chunksize=10000, unchecked=True)
 
   with open(file_) as f:
     with ProcessPoolExecutor(max_workers=cpu_count()) as executor:
-      total = 0 
+      total = 0
       for idx, adj_chunk in enumerate(executor.map(parse_func, grouper(int(chunksize), f))):
           adjlist.extend(adj_chunk)
           total += len(adj_chunk)
-  
+
   t1 = time()
 
   logger.info('Parsed {} edges with {} chunks in {}s'.format(total, idx, t1-t0))
@@ -241,7 +241,7 @@ def load_adjacencylist(file_, undirected=False, chunksize=10000, unchecked=True)
     t1 = time()
     logger.info('Made graph undirected in {}s'.format(t1-t0))
 
-  return G 
+  return G
 
 
 def load_edgelist(file_, undirected=True):
@@ -254,7 +254,7 @@ def load_edgelist(file_, undirected=True):
       G[x].append(y)
       if undirected:
         G[y].append(x)
-  
+
   G.make_consistent()
   return G
 
@@ -298,7 +298,7 @@ def from_numpy(x, undirected=True):
 
 def from_adjlist(adjlist):
     G = Graph()
-    
+
     for row in adjlist:
         node = row[0]
         neighbors = row[1:]
@@ -309,7 +309,7 @@ def from_adjlist(adjlist):
 
 def from_adjlist_unchecked(adjlist):
     G = Graph()
-    
+
     for row in adjlist:
         node = row[0]
         neighbors = row[1:]


### PR DESCRIPTION
In Deepwalk, each random walk is represented by a list of **integers**. These random walks are treated as sentences in the Gensim Word2Vec model.

However, the higher version of Gensim requires that each sentence must be a list of **strings**, instead of integers. This pull request fix the compatibility issue with Gensim by converting each random walk to a list of strings.