### PR TITLE
fix import

### DIFF
--- a/deepwalk/__main__.py
+++ b/deepwalk/__main__.py
@@ -13,7 +13,7 @@ import logging
 from deepwalk import graph
 from deepwalk import walks as serialized_walks
 from gensim.models import Word2Vec
-from skipgram import Skipgram
+from deepwalk.skipgram import Skipgram
 
 from six import text_type as unicode
 from six import iteritems


### PR DESCRIPTION
direct use `from skipgram import Skipgram` can cause errors; fix it to use absolute import.