### PR TITLE
Add n-gram option for embedding training

### DIFF
--- a/deepwalk/phrases.py
+++ b/deepwalk/phrases.py
@@ -1,0 +1,36 @@
+import logging
+
+from gensim.models.phrases import Phrases, Phraser
+
+logger = logging.getLogger("deepwalk")
+
+def build_ngram(walks, ngram, min_count=5, threshold=10.0,
+                max_vocab_size=40000000, delimiter=b'_', scoring='default'):
+    """
+    Compose n-gram on the fly given tunable parameters, work for both in-memory or out-of-core computations.
+
+    Required Parameters
+    - walks: iterable list of str (iterable list of list of string, or deepwalk.walks.WalksCorpus object)
+            Input random walk sequences. Can be either 'List of list of tokens'(in-memory) or 'deepwalk.walks.WalksCorpus' object(out-of-core)
+    - ngram: int
+            Specify the n of n-gram, e.g.: ngram=2 to compose bigrams.
+
+    Optional Parameters
+      Referece to gensim.models.phrases.Phrases
+
+    Return
+    - iterable list of str (iterable list of list of string, or deepwalk.walks.WalksCorpus object)
+    """
+
+    if ngram<2:
+        logger.warning("ngram must >=2! Skip building ngram.")
+        return walks
+
+    for n in range(2,ngram+1):
+        logger.info("Composing "+str(n)+"-grams...")
+        ngram_phrases = Phrases(walks, min_count=min_count, threshold=threshold, max_vocab_size=max_vocab_size,
+                                delimiter=delimiter, scoring=scoring)
+        ngram_phraser = Phraser(ngram_phrases)
+        walks = ngram_phraser[walks]
+
+    return walks


### PR DESCRIPTION
After getting random walk sequences, we treat those as word sequence and apply gensim word2vec for embeddings.
It would be interesting to test whether using n-gram would be effective here as it does in NLP.

**Feature implemented:** n-gram Phrases and Phraser by gensim, test successfully for both in-memory(data_size<max_memory) and out-of-core(data_size>max_memory) on local machine.

**_Test has been carried out, please find below log:_**

python setup.py test (after removing 'from deepwalk import deepwalk' in test_deepwalk.py)

> running test
> /Users/i351465/miniconda3/envs/deepwalk-dev/lib/python3.6/site-packages/setuptools/dist.py:517: UserWarning: Module argparse was already imported from /Users/i351465/miniconda3/envs/deepwalk-dev/lib/python3.6/argparse.py, but /Users/i351465/miniconda3/envs/deepwalk-dev/lib/python3.6/site-packages/argparse-1.4.0-py3.6.egg is being added to sys.path
>   pkg_resources.working_set.add(dist, replace=True)
> running egg_info
> writing deepwalk.egg-info/PKG-INFO
> writing dependency_links to deepwalk.egg-info/dependency_links.txt
> writing entry points to deepwalk.egg-info/entry_points.txt
> writing requirements to deepwalk.egg-info/requires.txt
> writing top-level names to deepwalk.egg-info/top_level.txt
> reading manifest file 'deepwalk.egg-info/SOURCES.txt'
> reading manifest template 'MANIFEST.in'
> warning: no previously-included files matching '__pycache__' found under directory '*'
> writing manifest file 'deepwalk.egg-info/SOURCES.txt'
> running build_ext
> test_something (tests.test_deepwalk.TestDeepwalk) ... ok
> 
> ----------------------------------------------------------------------
> Ran 1 test in 0.000s
> 
> OK
> 

tox test:

> ____________________________________________________________________________________ summary _____________________________________________________________________________________
>   py26: commands succeeded
>   py27: commands succeeded
>   py33: commands succeeded
> ERROR:  py34: InterpreterNotFound: python3.4
*NOTE: tested python-3.4 manually with conda environment, working fine. The failure here should be test scripts issue.