### PR TITLE
Fix from_networkx()

### DIFF
--- a/deepwalk/graph.py
+++ b/deepwalk/graph.py
@@ -262,7 +262,7 @@ def load_matfile(file_, variable_name="network", undirected=True):
 def from_networkx(G_input, undirected=True):
     G = Graph()
 
-    for idx, x in enumerate(G_input.nodes_iter()):
+    for idx, x in enumerate(G_input.nodes()):
         for y in iterkeys(G_input[x]):
             G[x].append(y)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six>=1.7.3
 gensim>=1.0.0
 scipy>=0.15.0
 psutil>=2.1.1
+networkx>=2.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ requirements = [
     'six>=1.7.3',
     'gensim>=1.0.0',
     'scipy>=0.15.0',
-    'psutil>=2.1.1'
+    'psutil>=2.1.1',
+    'networkx>=2.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
nodes_iter() used in from_networkx() method of GraRep class has been outdated since Networkx v2.0. Instead, the nodes method is provided.
And the nodes method is available NetworkX version 2.0 and earlier.
