### PR TITLE
Add option for pretrained embeddings

### DIFF
--- a/deepwalk/__main__.py
+++ b/deepwalk/__main__.py
@@ -76,10 +76,10 @@ def process(args):
     model = Word2Vec(size=args.representation_size, window=args.window_size, min_count=0, sg=1, hs=1, workers=args.workers)
     model.build_vocab(walks)
     total_examples = model.corpus_count
-    if args.embeddings is not None:
-      pretrained_embeddings = KeyedVectors.load_word2vec_format(args.embeddings, binary=False)
+    if args.pretrained is not None:
+      pretrained_embeddings = KeyedVectors.load_word2vec_format(args.pretrained, binary=False)
       model.build_vocab([list(pretrained_embeddings.vocab.keys())], update=True)
-      model.intersect_word2vec_format(args.embeddings, binary=False, lockf=1.0)
+      model.intersect_word2vec_format(args.pretrained, binary=False, lockf=1.0)
     model.train(walks, total_examples=total_examples, epochs=model.iter)
   else:
     print("Data size {} is larger than limit (max-memory-data-size: {}).  Dumping walks to disk.".format(data_size, args.max_memory_data_size))
@@ -104,10 +104,10 @@ def process(args):
                      window=args.window_size, min_count=0, trim_rule=None, workers=args.workers)
     model.build_vocab(vocab_walks_corpus)
     total_examples = model.corpus_count
-    if args.embeddings is not None:
-      pretrained_embeddings = KeyedVectors.load_word2vec_format(args.embeddings, binary=False)
+    if args.pretrained is not None:
+      pretrained_embeddings = KeyedVectors.load_word2vec_format(args.pretrained, binary=False)
       model.build_vocab([list(pretrained_embeddings.vocab.keys())], update=True)
-      model.intersect_word2vec_format(args.embeddings, binary=False, lockf=1.0)
+      model.intersect_word2vec_format(args.pretrained, binary=False, lockf=1.0)
     model.train(train_walks_corpus, total_examples=total_examples, epochs=model.iter)
 
   model.wv.save_word2vec_format(args.output)


### PR DESCRIPTION
As per #107, this PR implements an extra parameter, `--pretrained`, that can be used to specify pre-trained embeddings that will be used as the initializers for the node embeddings. The specified file must be in the traditional C node2vec format (same as the program outputs).

Help Wanted: how to check if the dimensions match? Either we assert that the loaded vectors have the same dimension as the value passed into the `--representation_size` parameter or we infer the representation size from the pre-trained embeddings (and make the parameters mutually exclusive).

Also, I read through the README to check if I needed to update something, but I decided that this new parameter didn't fit anywhere, so I should either not alter it or add a new subsection (up to you). 