### PR TITLE
removal of vestigial gensim import

### DIFF
--- a/deepwalk/__main__.py
+++ b/deepwalk/__main__.py
@@ -72,7 +72,7 @@ def process(args):
     walks = graph.build_deepwalk_corpus(G, num_paths=args.number_walks,
                                         path_length=args.walk_length, alpha=0, rand=random.Random(args.seed))
     print("Training...")
-    model = Word2Vec(walks, size=args.representation_size, window=args.window_size, min_count=0, sg=1, hs=1, workers=args.workers)
+    model = Word2Vec(walks, vector_size=args.representation_size, window=args.window_size, min_count=0, sg=1, hs=1, workers=args.workers)
   else:
     print("Data size {} is larger than limit (max-memory-data-size: {}).  Dumping walks to disk.".format(data_size, args.max_memory_data_size))
     print("Walking...")

--- a/deepwalk/skipgram.py
+++ b/deepwalk/skipgram.py
@@ -3,11 +3,10 @@ from concurrent.futures import ProcessPoolExecutor
 import logging
 from multiprocessing import cpu_count
 from six import string_types
-
 from gensim.models import Word2Vec
-from gensim.models.word2vec import Vocab
 
 logger = logging.getLogger("deepwalk")
+
 
 class Skipgram(Word2Vec):
     """A subclass to allow more customization of the Word2Vec internals."""
@@ -24,7 +23,7 @@ class Skipgram(Word2Vec):
         kwargs["sg"] = 1
         kwargs["hs"] = 1
 
-        if vocabulary_counts != None:
-          self.vocabulary_counts = vocabulary_counts
+        if vocabulary_counts is not None:
+            self.vocabulary_counts = vocabulary_counts
 
         super(Skipgram, self).__init__(**kwargs)


### PR DESCRIPTION
`deepwalk.skipgram` imports but does not use an object from gensim, `Vocab` , which has been removed in `gensim>=4.0.0`. It wasn't being used anyway so this doesn't affect anything; other than allowing `deepwalk` to be ran in command line once more. Technically, I only ran `deepwalk --help` because I just recently cloned the repo, so there could be other gensim compatibility issues elsewhere as well. 